### PR TITLE
adding template specialization for concatenating zero-sized strings

### DIFF
--- a/include/ak_toolkit/static_string.hpp
+++ b/include/ak_toolkit/static_string.hpp
@@ -168,6 +168,12 @@ constexpr string<N1 + N2, char_array> operator+(string<N1, TL> const& l, string<
     return string<N1 + N2, char_array>(l, r);
 }
 
+template <int N1, typename TL, typename TR>
+constexpr string<N1, TL> operator+(string<N1, TL> const& l, string<0, TR> const& r)
+{
+    return l;
+}
+
 template <int N1_1, int N2, typename TR>
 constexpr string<N1_1 - 1 + N2, char_array> operator+(const char (&l)[N1_1], string<N2, TR> const& r)
 {


### PR DESCRIPTION
This specialization acts as a pass-through in the event that one attempts to concatenate an empty string literal onto another string literal.

The motivation for this PR was the discovery that clang would complain about range issues when creating objects that would use recursion to concatenate internal string literals where the escape function would return an empty literal string.  
